### PR TITLE
ReferenceError: fs is not defined 에러 수정했습니다.

### DIFF
--- a/generators/app/templates/swagger/index.js
+++ b/generators/app/templates/swagger/index.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const path = require('path');
 const swaggerParser = require('swagger-parser');
+const fs = require('fs');
 
 const checkSwaggerSpec = () => {
   const docs = fs


### PR DESCRIPTION
프로젝트 바로 만들어서 실행하면 app/config/swagger/index.js  파일에서 
ReferenceError: fs is not defined에러가 발생하는데 그 부분 수정해놨습니다.